### PR TITLE
Preserve options when type has options

### DIFF
--- a/src/ui/templates/Form/signals.ts
+++ b/src/ui/templates/Form/signals.ts
@@ -16,7 +16,7 @@ export const createField = (field?: Field) => {
     if (!newType) return;
     setType(newType);
     const _has = hasOptions(newType);
-    if (_has) setOptions(['']);
+    if (_has) setOptions(prev => prev ?? ['']);
     else setOptions(undefined);
   };
 


### PR DESCRIPTION
Ensure that options are retained if the new type has options, preventing them from being reset to an empty array.